### PR TITLE
increase image size

### DIFF
--- a/ARDAudiothek/API.pm
+++ b/ARDAudiothek/API.pm
@@ -356,7 +356,7 @@ sub _episodeFromJson {
 
 sub selectImageFormat {
     my $imageUrl = shift;
-    my $thumbnailSize = 2.0 * $serverPrefs->{prefs}->{thumbSize};
+    my $thumbnailSize = 10.0 * $serverPrefs->{prefs}->{thumbSize};
 
     $imageUrl =~ s/{ratio}/1x1/i; # for compability
     $imageUrl =~ s/16x9/1x1/i;


### PR DESCRIPTION
Hi @mzedd,

just a small tweak to get rid of the pixelated images for "now playing" screen on squeezebox radio display as well as within material skin on HD displays.
Images look way sharper now. As image sources are scalable anyways, there should be no downside apllying this. At least personally I couldn't figure any issues in comparison.

cheers