### PR TITLE
Add Dependabot for updating github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "10:00"
+  open-pull-requests-limit: 5
+  target-branch: develop

--- a/.github/workflows/create-nightly-release.yml
+++ b/.github/workflows/create-nightly-release.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete nightly release
-        uses: dev-drprasad/delete-tag-and-release@v0.2.0
+        uses: dev-drprasad/delete-tag-and-release@v1.1
         with:
           delete_release: true
           tag_name: nightly


### PR DESCRIPTION
Hi @mzedd,

this will install Dependabot which will create a PR if one of your actions becomes outdated, updating it automatically.